### PR TITLE
[mdaiter]: added Cargo.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /cp2k
 *.mp4
 *.webm
+Cargo.lock


### PR DESCRIPTION
You might want to add the Cargo.lock to the .gitignore, just to ensure it doesn't get dragged in by accident